### PR TITLE
Ensure everything is on gpu and other stuff

### DIFF
--- a/flux_mod/model.py
+++ b/flux_mod/model.py
@@ -220,14 +220,14 @@ class FluxMod(nn.Module):
         device = img.device
         dtype = img.dtype
         mod_index_length = 344 + 12
-        distill_timestep = timestep_embedding(torch.tensor(timesteps), 16).to(device=device, dtype=dtype)
-        distil_guidance = timestep_embedding(torch.tensor(guidance), 16).to(device=device, dtype=dtype)
+        distill_timestep = timestep_embedding(timesteps, 16).to(device=device, dtype=dtype)
+        distil_guidance = timestep_embedding(guidance, 16).to(device=device, dtype=dtype)
         # get all modulation index
-        modulation_index = timestep_embedding(torch.tensor(list(range(mod_index_length))), 32).to(device=device, dtype=dtype)
+        modulation_index = timestep_embedding(torch.arange(0, mod_index_length).to(device=device), 32).to(device=device, dtype=dtype)
         # we need to broadcast the modulation index here so each batch has all of the index
-        modulation_index = modulation_index.unsqueeze(0).repeat(img.shape[0], 1, 1)
+        modulation_index = modulation_index.unsqueeze(0)
         # and we need to broadcast timestep and guidance along too
-        timestep_guidance = torch.cat([distill_timestep, distil_guidance], dim=1).unsqueeze(1).repeat(1, mod_index_length, 1)
+        timestep_guidance = torch.cat([distill_timestep, distil_guidance], dim=1).unsqueeze(1).expand(1, mod_index_length, 32)
         # then and only then we could concatenate it together
         input_vec = torch.cat([timestep_guidance, modulation_index], dim=-1)
 


### PR DESCRIPTION
```torch.tensor(list(range(mod_index_length)))``` was on the cpu and breaks cuda graph.

Removed putting timesteps and guidance in ```torch.tensor``` to avoid warnings.
Removed ```.repeat(img.shape[0], 1, 1)``` which doesn't seem to do anything.
Replaced ```.repeat(1, mod_index_length, 1)``` with ```.expand(1, mod_index_length, 32)``` because apparently expand does the same thing without copying memory.