### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A modulation layer addon for Flux that reduces model size to 8.8B parameters wit
 
 ComfyUI_FluxMod acts as a plugin for Flux, enabling you to run Flux Dev and Flux Schnell on more consumer-friendly hardware. This is achieved by utilizing a modulation layer that significantly reduces the parameter count while maintaining quality.
 
-> **Note**: You still need the original Flux Dev or Flux Schnell model to use this addon.
+> **Note**: You still need a Flux Dev or Flux Schnell model to use this addon.
 
 ## Table of Contents
 
@@ -27,7 +27,7 @@ ComfyUI_FluxMod acts as a plugin for Flux, enabling you to run Flux Dev and Flux
 ## Requirements
 
 - ComfyUI installation
-- Original Flux model (Dev or Schnell)
+- Flux model (Dev or Schnell). Tested to work with the original models, may not work with third party versions such as fine tunes.
 - [universal_modulator.safetensors](https://huggingface.co/lodestone-horizon/flux-essence)
 
 ## Installation
@@ -65,13 +65,14 @@ git clone https://github.com/lodestone-rock/ComfyUI_FluxMod.git
 
 | Node                    | Description                              | Options                                                                                                                             |
 | ----------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| FluxModCheckpointLoader | Primary checkpoint loading node          | • **ckpt_name**: Original Flux model path<br>• **guidance_name**: Modulation addon path<br>• **quant_mode**: Quantization selection |
+| FluxModCheckpointLoader | Primary checkpoint loading node          | • **ckpt_name**: Flux model path<br>• **guidance_name**: Modulation addon path<br>• **quant_mode**: Quantization selection          |
 | KSamplerMod             | Modified KSampler for 8-bit quantization | • **activation_casting**: Switch between bf16 and fp16                                                                              |
+| FluxModSamplerWrapper   | Sampler wrapper for 8-bit quantization   | • **activation_casting**: Switch between bf16 and fp16                                                                              |
 | SkipLayerForward        | Skip specific Flux layers                | • **skip_mmdit_layers**: Which MMDiT layer to skip<br>• **skip_dit_layers**: Which DIT layers to skip (-1 to disable)               |
 
 ## Usage
 
-> ⚠️ **Important**: When using `float8_e4m3fn` or `float8_e5m2` quantization modes, you must use the `KSamplerMod` node instead of the regular KSampler. This requirement does not apply when using `bf16` mode.
+> ⚠️ **Important**: When using `float8_e4m3fn` or `float8_e5m2` quantization modes, you must use either the `KSamplerMod` node instead of the regular KSampler or `FluxModSamplerWrapper` for `SamplerCustom` or other sampler nodes that take a `SAMPLER` input. This requirement does not apply when using `bf16` mode in `FluxModCheckpointLoader` or when starting ComfyUI with `--fast`.
 
 1. Double click workspace → search "FluxModCheckpointLoader"
 2. Select your Flux model in `ckpt_name`

--- a/flux_mod/layers.py
+++ b/flux_mod/layers.py
@@ -7,32 +7,26 @@ from torch import Tensor, nn
 from .math import attention, rope
 import comfy.ops
 import comfy.ldm.common_dit
-
-
-class EmbedND(nn.Module):
-    def __init__(self, dim: int, theta: int, axes_dim: list):
-        super().__init__()
-        self.dim = dim
-        self.theta = theta
-        self.axes_dim = axes_dim
-
-    def forward(self, ids: Tensor) -> Tensor:
-        n_axes = ids.shape[-1]
-        emb = torch.cat(
-            [rope(ids[..., i], self.axes_dim[i], self.theta) for i in range(n_axes)],
-            dim=-3,
-        )
-
-        return emb.unsqueeze(1)
+from comfy.ldm.flux import layers
+from comfy.ldm.flux.layers import (
+    EmbedND,
+    MLPEmbedder,
+    RMSNorm,
+    QKNorm,
+    SelfAttention,
+    ModulationOut,
+    Modulation,
+    timestep_embedding,
+)
 
 
 class Approximator(nn.Module):
-    def __init__(self, in_dim: int, out_dim: int, hidden_dim: int, n_layers = 4):
+    def __init__(self, in_dim: int, out_dim: int, hidden_dim: int, n_layers = 4, operations=None):
         super().__init__()
-        self.in_proj = nn.Linear(in_dim, hidden_dim, bias=True)
-        self.layers = nn.ModuleList([MLPEmbedder( hidden_dim, hidden_dim) for x in range( n_layers)])
-        self.norms = nn.ModuleList([RMSNorm( hidden_dim) for x in range( n_layers)])
-        self.out_proj = nn.Linear(hidden_dim, out_dim)
+        self.in_proj = operations.Linear(in_dim, hidden_dim, bias=True)
+        self.layers = nn.ModuleList([MLPEmbedder( hidden_dim, hidden_dim, operations=operations) for x in range( n_layers)])
+        self.norms = nn.ModuleList([RMSNorm( hidden_dim, operations=operations) for x in range( n_layers)])
+        self.out_proj = operations.Linear(hidden_dim, out_dim)
 
     @property
     def device(self):
@@ -50,121 +44,13 @@ class Approximator(nn.Module):
         return x
 
 
-def timestep_embedding(t: Tensor, dim, max_period=10000, time_factor: float = 1000.0):
-    """
-    Create sinusoidal timestep embeddings.
-    :param t: a 1-D Tensor of N indices, one per batch element.
-                      These may be fractional.
-    :param dim: the dimension of the output.
-    :param max_period: controls the minimum frequency of the embeddings.
-    :return: an (N, D) Tensor of positional embeddings.
-    """
-    t = time_factor * t
-    half = dim // 2
-    freqs = torch.exp(-math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32, device=t.device) / half)
+class DoubleStreamBlock(layers.DoubleStreamBlock):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        del self.img_mod
+        del self.txt_mod
 
-    args = t[:, None].float() * freqs[None]
-    embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
-    if dim % 2:
-        embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
-    if torch.is_floating_point(t):
-        embedding = embedding.to(t)
-    return embedding
-
-class MLPEmbedder(nn.Module):
-    def __init__(self, in_dim: int, hidden_dim: int, dtype=None, device=None, operations=nn):
-        super().__init__()
-        self.in_layer = operations.Linear(in_dim, hidden_dim, bias=True, dtype=dtype, device=device)
-        self.silu = nn.SiLU()
-        self.out_layer = operations.Linear(hidden_dim, hidden_dim, bias=True, dtype=dtype, device=device)
-
-    def forward(self, x: Tensor) -> Tensor:
-        return self.out_layer(self.silu(self.in_layer(x)))
-
-
-class RMSNorm(torch.nn.Module):
-    def __init__(self, dim: int, dtype=None, device=None, operations=nn):
-        super().__init__()
-        self.scale = nn.Parameter(torch.empty((dim), dtype=dtype, device=device))
-
-    def forward(self, x: Tensor):
-        return comfy.ldm.common_dit.rms_norm(x, self.scale, 1e-6)
-
-
-class QKNorm(torch.nn.Module):
-    def __init__(self, dim: int, dtype=None, device=None, operations=nn):
-        super().__init__()
-        self.query_norm = RMSNorm(dim, dtype=dtype, device=device, operations=operations)
-        self.key_norm = RMSNorm(dim, dtype=dtype, device=device, operations=operations)
-
-    def forward(self, q: Tensor, k: Tensor, v: Tensor) -> tuple:
-        q = self.query_norm(q)
-        k = self.key_norm(k)
-        return q.to(v), k.to(v)
-
-
-class SelfAttention(nn.Module):
-    def __init__(self, dim: int, num_heads: int = 8, qkv_bias: bool = False, dtype=None, device=None, operations=nn):
-        super().__init__()
-        self.num_heads = num_heads
-        head_dim = dim // num_heads
-
-        self.qkv = operations.Linear(dim, dim * 3, bias=qkv_bias, dtype=dtype, device=device)
-        self.norm = QKNorm(head_dim, dtype=dtype, device=device, operations=operations)
-        self.proj = operations.Linear(dim, dim, dtype=dtype, device=device)
-
-
-@dataclass
-class ModulationOut:
-    shift: Tensor
-    scale: Tensor
-    gate: Tensor
-
-
-class Modulation(nn.Module):
-    def __init__(self, dim: int, double: bool, dtype=None, device=None, operations=nn):
-        super().__init__()
-        self.is_double = double
-        self.multiplier = 6 if double else 3
-        self.lin = operations.Linear(dim, self.multiplier * dim, bias=True, dtype=dtype, device=device)
-
-    def forward(self, vec: Tensor) -> tuple:
-        out = self.lin(nn.functional.silu(vec))[:, None, :].chunk(self.multiplier, dim=-1)
-
-        return (
-            ModulationOut(*out[:3]),
-            ModulationOut(*out[3:]) if self.is_double else None,
-        )
-
-
-class DoubleStreamBlock(nn.Module):
-    def __init__(self, hidden_size: int, num_heads: int, mlp_ratio: float, qkv_bias: bool = False, dtype=None, device=None, operations=nn):
-        super().__init__()
-
-        mlp_hidden_dim = int(hidden_size * mlp_ratio)
-        self.num_heads = num_heads
-        self.hidden_size = hidden_size
-        self.img_norm1 = operations.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6, dtype=dtype, device=device)
-        self.img_attn = SelfAttention(dim=hidden_size, num_heads=num_heads, qkv_bias=qkv_bias, dtype=dtype, device=device, operations=operations)
-
-        self.img_norm2 = operations.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6, dtype=dtype, device=device)
-        self.img_mlp = nn.Sequential(
-            operations.Linear(hidden_size, mlp_hidden_dim, bias=True, dtype=dtype, device=device),
-            nn.GELU(approximate="tanh"),
-            operations.Linear(mlp_hidden_dim, hidden_size, bias=True, dtype=dtype, device=device),
-        )
-
-        self.txt_norm1 = operations.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6, dtype=dtype, device=device)
-        self.txt_attn = SelfAttention(dim=hidden_size, num_heads=num_heads, qkv_bias=qkv_bias, dtype=dtype, device=device, operations=operations)
-
-        self.txt_norm2 = operations.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6, dtype=dtype, device=device)
-        self.txt_mlp = nn.Sequential(
-            operations.Linear(hidden_size, mlp_hidden_dim, bias=True, dtype=dtype, device=device),
-            nn.GELU(approximate="tanh"),
-            operations.Linear(mlp_hidden_dim, hidden_size, bias=True, dtype=dtype, device=device),
-        )
-
-    def forward(self, img: Tensor, txt: Tensor, pe: Tensor, distill_vec: Tensor=None):
+    def forward(self, img: Tensor, txt: Tensor, pe: Tensor, distill_vec: Tensor | None=None):
         (img_mod1, img_mod2), (txt_mod1, txt_mod2) = distill_vec
 
         # prepare image for attention
@@ -202,42 +88,17 @@ class DoubleStreamBlock(nn.Module):
         return img, txt
 
 
-class SingleStreamBlock(nn.Module):
+class SingleStreamBlock(layers.SingleStreamBlock):
     """
     A DiT block with parallel linear layers as described in
     https://arxiv.org/abs/2302.05442 and adapted modulation interface.
     """
 
-    def __init__(
-        self,
-        hidden_size: int,
-        num_heads: int,
-        mlp_ratio: float = 4.0,
-        qk_scale: float = None,
-        dtype=None,
-        device=None,
-        operations=nn
-    ):
-        super().__init__()
-        self.hidden_dim = hidden_size
-        self.num_heads = num_heads
-        head_dim = hidden_size // num_heads
-        self.scale = qk_scale or head_dim**-0.5
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        del self.modulation
 
-        self.mlp_hidden_dim = int(hidden_size * mlp_ratio)
-        # qkv and mlp_in
-        self.linear1 = operations.Linear(hidden_size, hidden_size * 3 + self.mlp_hidden_dim, dtype=dtype, device=device)
-        # proj and mlp_out
-        self.linear2 = operations.Linear(hidden_size + self.mlp_hidden_dim, hidden_size, dtype=dtype, device=device)
-
-        self.norm = QKNorm(head_dim, dtype=dtype, device=device, operations=operations)
-
-        self.hidden_size = hidden_size
-        self.pre_norm = operations.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6, dtype=dtype, device=device)
-
-        self.mlp_act = nn.GELU(approximate="tanh")
-
-    def forward(self, x: Tensor, pe: Tensor, distill_vec: Tensor=None) -> Tensor:
+    def forward(self, x: Tensor, pe: Tensor, distill_vec: Tensor | None=None) -> Tensor:
         mod = distill_vec
         x_mod = (1 + mod.scale) * self.pre_norm(x) + mod.shift
         qkv, mlp = torch.split(self.linear1(x_mod), [3 * self.hidden_size, self.mlp_hidden_dim], dim=-1)
@@ -255,13 +116,12 @@ class SingleStreamBlock(nn.Module):
         return x
 
 
-class LastLayer(nn.Module):
-    def __init__(self, hidden_size: int, patch_size: int, out_channels: int, dtype=None, device=None, operations=nn):
-        super().__init__()
-        self.norm_final = operations.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6, dtype=dtype, device=device)
-        self.linear = operations.Linear(hidden_size, patch_size * patch_size * out_channels, bias=True, dtype=dtype, device=device)
+class LastLayer(layers.LastLayer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        del self.adaLN_modulation
 
-    def forward(self, x: Tensor, distill_vec: Tensor=None) -> Tensor:
+    def forward(self, x: Tensor, distill_vec: Tensor | None=None) -> Tensor:
         shift, scale = distill_vec
         shift = shift.squeeze(1)
         scale = scale.squeeze(1)

--- a/flux_mod/model.py
+++ b/flux_mod/model.py
@@ -220,10 +220,10 @@ class FluxMod(nn.Module):
         device = img.device
         dtype = img.dtype
         mod_index_length = 344 + 12
-        distill_timestep = timestep_embedding(torch.tensor(timesteps), 16).to(device=device, dtype=dtype)
-        distil_guidance = timestep_embedding(torch.tensor(guidance), 16).to(device=device, dtype=dtype)
+        distill_timestep = timestep_embedding(timesteps.detach().clone(), 16).to(device=device, dtype=dtype)
+        distil_guidance = timestep_embedding(guidance.detach().clone(), 16).to(device=device, dtype=dtype)
         # get all modulation index
-        modulation_index = timestep_embedding(torch.tensor(list(range(mod_index_length))), 32).to(device=device, dtype=dtype)
+        modulation_index = timestep_embedding(torch.arange(mod_index_length), 32).to(device=device, dtype=dtype)
         # we need to broadcast the modulation index here so each batch has all of the index
         modulation_index = modulation_index.unsqueeze(0).repeat(img.shape[0], 1, 1)
         # and we need to broadcast timestep and guidance along too


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/decdc9ef-0763-4d1c-b3ae-e452b5155c53)
(He's a bit dumb because he was made with `--fast` and lite patch.)

This pull:
* Enables support with third-party checkpoints. Tested with https://civitai.com/models/686814/jib-mix-flux and https://civitai.com/models/673188/acorn-is-spinning-flux
* Adds a `FluxModSamplerWrapper` node that enables using FluxMod with samplers like `SamplerCustom`.
* Refactors the model loading to use the existing Flux modules when possible and passes `operations` through. Makes FluxMod work with ComfyUI's `--fast` option (though it seems to reduce quality a fair amount). Also appears to fix a problem where some tensors would be on the wrong device when there was a lot of memory pressure (I could reliably reproduce it doing a 3x upscale from 1024x1024).

Tested to work on my system (Linux, 4060Ti) with the finetunes listed above, normal Dev, Schnell, `--fast` or not and lite patch enabled or not.

The first two bullet points in the list of changes are pretty minimal from a code standpoint. This pull could be split up to separate out the loader/layer refactoring since it is fairly complex.