### PR TITLE
Chroma Style Model node for FLUX-Redux

### DIFF
--- a/flux_mod/nodes.py
+++ b/flux_mod/nodes.py
@@ -128,6 +128,47 @@ class ChromaPromptTruncation:
         return (c,)
 
 
+class ChromaStyleModelApply:
+    NodeId = "ChromaStyleModelApply"
+    NodeName = "Chroma Style Model"
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": {"conditioning": ("CONDITIONING", ),
+                             "style_model": ("STYLE_MODEL", ),
+                             "clip_vision_output": ("CLIP_VISION_OUTPUT", ),
+                             "strength": ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.001}),
+                             "truncate_percent": ("FLOAT", {"default": 1.00, "min": -1.0, "max": 1.0, "step": 0.001, "tooltip": "Truncates clipvision conditioning to the first truncate_percent values when > 0. Truncates the last |truncate_percent| values when < 0."}),
+                             }}
+    RETURN_TYPES = ("CONDITIONING",)
+    FUNCTION = "apply_stylemodel"
+
+    CATEGORY = "conditioning/style_model"
+
+    def apply_stylemodel(self, conditioning, style_model, clip_vision_output, strength, truncate_percent):
+        cond = style_model.get_cond(clip_vision_output).flatten(start_dim=0, end_dim=1).unsqueeze(dim=0)
+
+        if truncate_percent < 1.0 and truncate_percent >= 0.0:
+            cond_norm = cond.norm(2) # Take stylemodel cond norm before truncation
+            cond = cond[:, :int(cond.shape[1] * truncate_percent), :] # Take first (729 * truncate_percent) blocks
+            cond *= cond_norm / cond.norm(2) # Re-normalize
+        elif truncate_percent < 0.0 and truncate_percent >= -1.0:
+            cond_norm = cond.norm(2)
+            cond = cond[:, -int(cond.shape[1] * abs(truncate_percent)):, :] # Take last (729 * truncate_percent) blocks
+            cond *= cond_norm / cond.norm(2)
+
+        cond *= strength # Normal strength
+
+        c_out = []
+        for t in conditioning:
+            (txt, keys) = t
+            keys = keys.copy()
+
+            c_out.append([torch.cat((txt, cond), dim=1), keys])
+
+        return (c_out,)
+
+
 class ModelMover:
     NodeId = "ModelMover"
     NodeName = "???"

--- a/flux_mod/nodes.py
+++ b/flux_mod/nodes.py
@@ -426,6 +426,7 @@ node_list = [
     FluxModSamplerWrapperNode,
     SkipLayerForward,
     ChromaPromptTruncation,
+    ChromaStyleModelApply,
 ]
 
 NODE_CLASS_MAPPINGS = {}


### PR DESCRIPTION
This PR adds a node for applying FLUX-Redux to Chroma, along with an extra parameter for CLIPVision conditioning truncation.

You can place this after Padding Removal.

The parameter `truncate_percent` will truncate clipvision conditioning to the first truncate_percent values when greater than 0. Truncates to the *last* |truncate_percent| values when set to less than 0. The benefit of this is increased prompt adherence while maintaining overall style or details.

For the following input prompt: `An intricate showing of an anthro male wolf sitting on a rock in a forest, anthro, male, solo, canine, canid, werewolf, muscular anthro, black body, black fur, reaching at viewer with his paws, detailed background, outdoors, outside. The scene is detailed, with a shallow depth of field focusing on the anthro wolf. The overall effect is high fantasy and cinematic.`

[Input CLIPVision image](https://github.com/user-attachments/assets/1794cc6d-30c3-4b7a-ad81-d51721ea13b3)

[Default output @ 1.0 strength](https://github.com/user-attachments/assets/3e883f46-12d7-4580-b538-15145631b180)

[0.15 truncate_percent @ 1.0 strength](https://github.com/user-attachments/assets/94db1e5a-d8d2-4f02-85bb-822f5f468215)

[-0.15 truncate_percent @ 1.0 strength](https://github.com/user-attachments/assets/072bcf35-3c24-4aaf-abc6-b07981cb8067)
