### PR TITLE
Explicitly import ComfyUI-GGUF's loader, ops, and nodes

### DIFF
--- a/flux_mod/loader.py
+++ b/flux_mod/loader.py
@@ -23,6 +23,11 @@ def ensure_gguf():
         return
     import sys
     gguf = sys.modules.get("ComfyUI-GGUF")
+
+    gguf.loader = sys.modules.get("ComfyUI-GGUF.loader")
+    gguf.ops = sys.modules.get("ComfyUI-GGUF.ops")
+    gguf.nodes = sys.modules.get("ComfyUI-GGUF.nodes")
+    
     if gguf is None:
         raise RuntimeError("Could not find ComfyUI-GGUF node: GGUF support requires ComfyUI-GGUF")
 

--- a/flux_mod/loader.py
+++ b/flux_mod/loader.py
@@ -22,12 +22,10 @@ def ensure_gguf():
     if gguf:
         return
     import sys
-    gguf = sys.modules.get("ComfyUI-GGUF")
-
-    gguf.loader = sys.modules.get("ComfyUI-GGUF.loader")
-    gguf.ops = sys.modules.get("ComfyUI-GGUF.ops")
-    gguf.nodes = sys.modules.get("ComfyUI-GGUF.nodes")
-    
+    gguf = next(
+        (mod for path, mod in sys.modules.items() if path.endswith("ComfyUI-GGUF")),
+        None
+    )
     if gguf is None:
         raise RuntimeError("Could not find ComfyUI-GGUF node: GGUF support requires ComfyUI-GGUF")
 


### PR DESCRIPTION
GGUF support wasn't working, this is due to the fact that the [`__init__.py` from ComfyUI-GGUF](https://github.com/city96/ComfyUI-GGUF/blob/6de4bdba30f142955ebf6f210533000ef094bf0e/__init__.py) doesn't expose loader, ops or nodes, leading to an attributeerror when trying to use a gguf chroma model.

This pr imports loader, ops and nodes, and assigns them as attributes to the `gguf` object, fixing `module 'ComfyUI-GGUF' has no attribute 'loader'`, which currently occurs when attempting to use a gguf version with the latest version of ComfyUI-GGUF.